### PR TITLE
Add Mouse Atlas to clustifyrdatahub

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: clustifyrdatahub
 Title: External data sets for clustifyr in ExperimentHub
-Version: 0.99.3
+Version: 0.99.4
 Description: References made from external single-cell mRNA sequencing data sets, stored as average gene expression matrices. For use with clustifyr <https://bioconductor.org/packages/clustifyr> to assign cell type identities.
 Authors@R: 
     c(person(given = "Rui",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,12 @@ Authors@R:
              family = "Hesselberth",
              role = "ctb",
              comment = c(ORCID = "0000-0002-6299-179X"),
-             email = "jay.hesselberth@gmail.com"))
+             email = "jay.hesselberth@gmail.com"),
+      person(given = "Sidhant",
+             family = "Puntambekar",
+             role = "ctb",
+             email = "sidhantnp@yahoo.com",
+      ))
 License: MIT + file LICENSE
 URL: https://rnabioco.github.io/clustifyrdatahub
 Depends:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -48,6 +48,6 @@ VignetteBuilder:
     knitr
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.1.0
+RoxygenNote: 7.1.1
 biocViews: SingleCellData, SequencingData, MicroarrayData, ExperimentHub, RNASeqData, PackageTypeData, ExpressionData
 BugReports: https://github.com/rnabioco/clustifyrdatahub/issues

--- a/NEWS
+++ b/NEWS
@@ -1,2 +1,3 @@
-Changes in version 0.99.4 (2020-09-02)
+Changes in version 0.99.0 (2020-07-02)
 + Cleanup for bioc
+Changes in version 0.99.4 (2020-09-02)

--- a/NEWS
+++ b/NEWS
@@ -1,2 +1,2 @@
-Changes in version 0.99.0 (2020-07-02)
+Changes in version 0.99.4 (2020-09-02)
 + Cleanup for bioc

--- a/R/resources.R
+++ b/R/resources.R
@@ -94,3 +94,12 @@
 #' @family ref
 #' @examples ref_MCA(metadata = TRUE)
 "ref_MCA"
+
+#' Atlas matrix of average gene expression aggregated from scRNA-seq data of mouse organisms
+#' 
+#' Data aggregated from NCBI Gene Expression Omnibus
+#' 
+#' @source <https://github.com/rnabioco/scRNA-seq-Cell-Ref-Matrix/blob/master/atlas/musMusculus/MouseAtlas.rds>
+#' @family ref
+#' @examples ref_MouseAtlas(metadata = True) 
+"ref_MouseAtlas"  

--- a/R/resources.R
+++ b/R/resources.R
@@ -101,5 +101,5 @@
 #' 
 #' @source <https://github.com/rnabioco/scRNA-seq-Cell-Ref-Matrix/blob/master/atlas/musMusculus/MouseAtlas.rds>
 #' @family ref
-#' @examples ref_MouseAtlas(metadata = True) 
-"ref_MouseAtlas"  
+#' @examples ref_mouse_atlas(metadata = True) 
+"ref_mouse_atlas"  

--- a/inst/scripts/make-metadata.R
+++ b/inst/scripts/make-metadata.R
@@ -75,7 +75,7 @@ main.data <- data.frame(
     "https://cells.ucsc.edu/cortex-dev/exprMatrix.tsv.gz",
     "https://scrnaseq-public-datasets.s3.amazonaws.com/scater-objects/baron-human.rds",
     "https://scrnaseq-public-datasets.s3.amazonaws.com/scater-objects/segerstolpe.rds",
-    "https://github.com/rnabioco/scRNA-seq-Cell-Ref-Matrix/blob/master/atlas/musMusculus/MouseAtlas.rds"
+    "https://github.com/rnabioco/scRNA-seq-Cell-Ref-Matrix/blob/master/atlas/musMusculus/MouseAtlas.rda"
   ),
   SourceVersion=c(
     "7",

--- a/inst/scripts/make-metadata.R
+++ b/inst/scripts/make-metadata.R
@@ -23,7 +23,7 @@ main.data <- data.frame(
     "Human cortex development scRNA-seq",
     "Human pancreatic cell scRNA-seq (inDrop)",
     "Human pancreatic cell scRNA-seq (SmartSeq2)",
-    "Mouse RNA-seq from 321 cell types"
+    "Mouse Atlas scRNA-seq from 321 cell types"
   ),
   RDataPath = file.path("clustifyrdatahub",
                         c("ref_MCA.rda",

--- a/inst/scripts/make-metadata.R
+++ b/inst/scripts/make-metadata.R
@@ -62,7 +62,7 @@ main.data <- data.frame(
     "TSV",
     "RDA",
     "RDA",
-    "RDS"
+    "RDA"
   ),
   SourceUrl=c(
     "https://ndownloader.figshare.com/files/10756795",

--- a/inst/scripts/make-metadata.R
+++ b/inst/scripts/make-metadata.R
@@ -9,7 +9,8 @@ main.data <- data.frame(
     "ref_hema_microarray",    
     "ref_cortex_dev",              
     "ref_pan_indrop",              
-    "ref_pan_smartseq2"    
+    "ref_pan_smartseq2",
+    "ref_mouse_atlas"
   ),
   Description = c(
     "Mouse Cell Atlas",
@@ -21,7 +22,8 @@ main.data <- data.frame(
     "Human hematopoietic cell microarray",
     "Human cortex development scRNA-seq",
     "Human pancreatic cell scRNA-seq (inDrop)",
-    "Human pancreatic cell scRNA-seq (SmartSeq2)"
+    "Human pancreatic cell scRNA-seq (SmartSeq2)",
+    "Mouse RNA-seq from 321 cell types"
   ),
   RDataPath = file.path("clustifyrdatahub",
                         c("ref_MCA.rda",
@@ -33,7 +35,8 @@ main.data <- data.frame(
                           "ref_hema_microarray.rda",
                           "ref_cortex_dev.rda",
                           "ref_pan_indrop.rda",
-                          "ref_pan_smartseq2.rda"
+                          "ref_pan_smartseq2.rda",
+                          "ref_mouse_atlas.rda"
                           )),
   BiocVersion="3.12",
   Genome=c(
@@ -58,7 +61,8 @@ main.data <- data.frame(
     "TXT",
     "TSV",
     "RDA",
-    "RDA"
+    "RDA",
+    "RDS"
   ),
   SourceUrl=c(
     "https://ndownloader.figshare.com/files/10756795",
@@ -70,7 +74,8 @@ main.data <- data.frame(
     "https://ftp.ncbi.nlm.nih.gov/geo/series/GSE24nnn/GSE24759/matrix/GSE24759_series_matrix.txt.gz",
     "https://cells.ucsc.edu/cortex-dev/exprMatrix.tsv.gz",
     "https://scrnaseq-public-datasets.s3.amazonaws.com/scater-objects/baron-human.rds",
-    "https://scrnaseq-public-datasets.s3.amazonaws.com/scater-objects/segerstolpe.rds"
+    "https://scrnaseq-public-datasets.s3.amazonaws.com/scater-objects/segerstolpe.rds",
+    "https://github.com/rnabioco/scRNA-seq-Cell-Ref-Matrix/blob/master/atlas/musMusculus/MouseAtlas.rds"
   ),
   SourceVersion=c(
     "7",
@@ -94,7 +99,8 @@ main.data <- data.frame(
     "Homo sapiens",
     "Homo sapiens",
     "Homo sapiens",
-    "Homo sapiens"
+    "Homo sapiens",
+    "Mus musculus"
   ),
   TaxonomyId=c(
     "10090",
@@ -119,7 +125,8 @@ main.data <- data.frame(
     "GEO",
     "UCSC",
     "S3",
-    "S3"
+    "S3",
+    "GEO"
   ),
   Maintainer="Rui Fu <raysinensis@gmail.com>",
   RDataClass="data.frame",

--- a/inst/scripts/make-ref-data/ref_mouse_atlas.R
+++ b/inst/scripts/make-ref-data/ref_mouse_atlas.R
@@ -1,0 +1,8 @@
+library(Seurat)
+library(clustifyr)
+library(tidyverse)
+
+mouse-atlas <- readRDA("https://github.com/rnabioco/scRNA-seq-Cell-Ref-Matrix/blob/master/atlas/musMusculus/MouseAtlas.rda")
+mouse-atlas_p <- parse_loc_object(mouse-atlas)
+
+usethis::use_data(mouse-atlas_p, compress = "xz", overwrite = TRUE)


### PR DESCRIPTION
This PR should add the scRNA-seq derived mouse atlas to the clustifyrdatahub repository. 

Deliverables: 

- [x] add description to R/resources.R;

- [x] add a column to inst/scripts/make-metadata.R, run that to generate inst/extdata/metadata.csv;

- [x] add inst/scripts/make-ref-data/ref_mouse_atlas.R (this doesn't have to run);

- [x] and then bump version to 0.99.4 in DESCRIPTION;

- [x] update NEWS; 

- [x] run devtools::document();